### PR TITLE
Update grammar.js for #3

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -101,6 +101,8 @@ module.exports = grammar({
     [$._statement, $.with_statement],
     [$._type, $.as_clause],
     [$._primary_expression, $.array_access_expression],
+    [$.generic_invocation_expression, $.array_access_expression],
+    [$.invocation_expression, $.generic_invocation_expression],
   ],
 
   word: ($) => $._identifier_token,
@@ -317,9 +319,10 @@ module.exports = grammar({
         $._literal,
         $.identifier,
         $.parenthesized_expression,
-        $.invocation_expression,  // Remove precedence here
-        $.member_access_expression,  // Remove precedence here
-        $.array_access_expression,  // Remove precedence here
+        $.generic_invocation_expression,  // Add this before regular invocation
+        $.invocation_expression,
+        $.member_access_expression,
+        $.array_access_expression,
         $.object_creation_expression,
         $.array_creation_expression,
         $.typeof_expression,
@@ -331,6 +334,16 @@ module.exports = grammar({
         $.with_expression,
         $.anonymous_object_creation_expression,
         $.with_member_access_expression
+      ),
+
+    generic_invocation_expression: ($) =>
+      prec(
+        PRECEDENCE.INVOCATION + 1,  
+        seq(
+          field("function", $._expression),
+          field("type_arguments", $.type_argument_list),
+          field("arguments", $.argument_list)
+        )
       ),
 
     parenthesized_expression: ($) => seq("(", $._expression, ")"),


### PR DESCRIPTION
## Solution

Here's the fix for the grammar:

```javascript grammar.js
// ... existing code ...

// Add a new rule for generic invocation
generic_invocation_expression: ($) =>
  prec(
    PRECEDENCE.INVOCATION + 1,  // Higher precedence than regular invocation
    seq(
      field("function", $._expression),
      field("type_arguments", $.type_argument_list),
      field("arguments", $.argument_list)
    )
  ),

// Update _primary_expression to include generic_invocation_expression
_primary_expression: ($) =>
  choice(
    $._literal,
    $.identifier,
    $.parenthesized_expression,
    $.generic_invocation_expression,  // Add this before regular invocation
    $.invocation_expression,
    $.member_access_expression,
    $.array_access_expression,
    $.object_creation_expression,
    $.array_creation_expression,
    $.typeof_expression,
    $.cast_expression,
    $.me_expression,
    $.mybase_expression,
    $.myclass_expression,
    $.if_expression,
    $.with_expression,
    $.anonymous_object_creation_expression,
    $.with_member_access_expression
  ),

// Update the conflicts section to include generic invocation conflicts
conflicts: ($) => [
  // ... existing conflicts ...
  [$.generic_invocation_expression, $.array_access_expression],
  [$.invocation_expression, $.generic_invocation_expression],
  // ... rest of conflicts ...
],

// ... rest of the file ...
```

### Explanation of the Solution

1. **New `generic_invocation_expression` rule**: This rule specifically handles method calls with generic type arguments, matching the pattern `method(Of Type)(arguments)`.

2. **Higher precedence**: Generic invocations get higher precedence than regular invocations to ensure they're matched first when both patterns could apply.

3. **Conflict resolution**: Added explicit conflicts between generic invocations and array access expressions since they both use parentheses.

4. **Ordering in `_primary_expression`**: Placed `generic_invocation_expression` before `invocation_expression` to ensure generic calls are tried first.

This solution properly parses generic method calls like:
- `Component.For(Of IService)()`
- `list.Where(Of String)(predicate)`
- `Factory.Create(Of MyClass, IInterface)()`

The fix ensures that generic type arguments are correctly recognized and parsed as part of the method invocation syntax rather than being misinterpreted as array access operations.