### PR TITLE
Update grammar.js

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -103,6 +103,7 @@ module.exports = grammar({
     [$._primary_expression, $.array_access_expression],
     [$.generic_invocation_expression, $.array_access_expression],
     [$.invocation_expression, $.generic_invocation_expression],
+    [$.dictionary_initializer, $.collection_initializer],
   ],
 
   word: ($) => $._identifier_token,
@@ -524,6 +525,7 @@ module.exports = grammar({
         )
       ),
     await_expression: ($) => seq(ci("Await"), $._expression),
+
     object_creation_expression: ($) =>
       seq(
         ci("New"),
@@ -532,10 +534,33 @@ module.exports = grammar({
         optional(
           field(
             "initializer",
-            choice($.object_initializer, $.collection_initializer)
+            choice(
+              $.object_initializer, 
+              $.collection_initializer,
+              $.dictionary_initializer  // Add this new option
+            )
           )
         )
       ),
+
+    dictionary_initializer: ($) =>
+      seq(
+        ci("From"), 
+        "{", 
+        commaSep($.dictionary_element), 
+        "}"
+      ),
+    
+    dictionary_element: ($) =>
+      seq(
+        "{",
+        field("key", $._expression),
+        ",",
+        field("value", $._expression),
+        "}"
+      ),
+
+
     object_initializer: ($) =>
       seq(ci("With"), "{", commaSep($.member_initializer), "}"),
     member_initializer: ($) =>
@@ -554,8 +579,11 @@ module.exports = grammar({
           field("value", $._expression)
         )
       ),
+
     collection_initializer: ($) =>
       seq(ci("From"), "{", commaSep($._expression), "}"),
+
+
     array_creation_expression: ($) =>
       seq(
         ci("New"),


### PR DESCRIPTION
## Proposed Solution
Add support for dictionary initialization by:

1. Creating a new `dictionary_initializer` rule:
```javascript
dictionary_initializer: ($) =>
  seq(
    ci("From"),
    "{",
    commaSep($.dictionary_element),
    "}"
  ),

dictionary_element: ($) =>
  seq(
    "{",
    field("key", $._expression),
    ",",
    field("value", $._expression),
    "}"
  ),
```

2. Update `object_creation_expression` and `variable_declarator` rules to include `dictionary_initializer` as a valid initializer option